### PR TITLE
Collapsing Symlinks in Windows builds

### DIFF
--- a/build_tarballs.jl
+++ b/build_tarballs.jl
@@ -23,6 +23,7 @@ echo installation complete
 if [[ ${target} == *-w64-mingw* ]]; then
     mkdir ${WORKSPACE}/tmp
     ls $prefix -Rl
+    cp $prefix/bin/libpng16.dll $prefix/lib # fix broken symlink
     cp -r -L $prefix/* ${WORKSPACE}/tmp
     echo collapsed symbolic links
     rm -r $prefix

--- a/build_tarballs.jl
+++ b/build_tarballs.jl
@@ -22,7 +22,7 @@ make install
 
 if [[ ${target} == *-w64-mingw* ]]; then
     mkdir ${WORKSPACE}/destdir/tmp
-    cp -L ${WORKSPACE}/destdir/lib/* ${WORKSPACE}/destdir/tmp
+    cp -r -L ${WORKSPACE}/destdir/lib/* ${WORKSPACE}/destdir/tmp
     rm -r ${WORKSPACE}/destdir/lib
     mv ${WORKSPACE}/destdir/tmp ${WORKSPACE}/destdir/lib
     ls ${WORKSPACE}/destdir/lib

--- a/build_tarballs.jl
+++ b/build_tarballs.jl
@@ -22,7 +22,7 @@ echo installation complete
 
 if [[ ${target} == *-w64-mingw* ]]; then
     mkdir ${WORKSPACE}/tmp
-    ls -Rl
+    ls $prefix -Rl
     cp -r -L $prefix/* ${WORKSPACE}/tmp
     echo collapsed symbolic links
     rm -r $prefix

--- a/build_tarballs.jl
+++ b/build_tarballs.jl
@@ -23,7 +23,7 @@ echo installation complete
 if [[ ${target} == *-w64-mingw* ]]; then
     mkdir ${WORKSPACE}/tmp
     ls $prefix -Rl
-    cp $prefix/lib/libpng.dll.a $prefix/bin # fix broken symlink
+    cp -d $prefix/lib/libpng.dll.a $prefix/bin # fix broken symlink
     cp -r -L $prefix/* ${WORKSPACE}/tmp
     echo collapsed symbolic links
     rm -r $prefix

--- a/build_tarballs.jl
+++ b/build_tarballs.jl
@@ -22,7 +22,7 @@ make install
 
 if [[ ${target} == *-w64-mingw* ]]; then
     mkdir ${WORKSPACE}/destdir/tmp
-    cp -r -L ${WORKSPACE}/destdir/lib/* ${WORKSPACE}/destdir/tmp
+    cp -r -L ${WORKSPACE}/destdir/lib ${WORKSPACE}/destdir/tmp
     rm -r ${WORKSPACE}/destdir/lib
     mv ${WORKSPACE}/destdir/tmp ${WORKSPACE}/destdir/lib
     ls ${WORKSPACE}/destdir/lib

--- a/build_tarballs.jl
+++ b/build_tarballs.jl
@@ -19,10 +19,12 @@ cd build/
 cmake -DCMAKE_INSTALL_PREFIX=$prefix -DCMAKE_TOOLCHAIN_FILE=/opt/$target/$target.toolchain ..
 make -j${ncore}
 make install
+echo installation complete
 
 if [[ ${target} == *-w64-mingw* ]]; then
     mkdir ${WORKSPACE}/destdir/tmp
     cp -r -L ${WORKSPACE}/destdir/lib/* ${WORKSPACE}/destdir/tmp
+    echo reolved symbolic links
     rm -r ${WORKSPACE}/destdir/lib
     mv ${WORKSPACE}/destdir/tmp ${WORKSPACE}/destdir/lib
     ls ${WORKSPACE}/destdir/lib

--- a/build_tarballs.jl
+++ b/build_tarballs.jl
@@ -23,7 +23,7 @@ echo installation complete
 if [[ ${target} == *-w64-mingw* ]]; then
     mkdir ${WORKSPACE}/tmp
     ls $prefix -Rl
-    cp $prefix/bin/libpng16.dll $prefix/lib # fix broken symlink
+    cp $prefix/lib/libpng.dll.a $prefix/bin # fix broken symlink
     cp -r -L $prefix/* ${WORKSPACE}/tmp
     echo collapsed symbolic links
     rm -r $prefix

--- a/build_tarballs.jl
+++ b/build_tarballs.jl
@@ -11,6 +11,7 @@ sources = [
 
 # Bash recipe for building across all platforms
 script = raw"""
+echo [ ***** Start Build! *****]
 cd $WORKSPACE/srcdir
 cd $WORKSPACE/srcdir
 cd libpng-1.6.31/
@@ -42,6 +43,7 @@ exit
 # platforms are passed in on the command line
 platforms = supported_platforms()
 @show platforms
+platforms = [Windows(:x86_64)]
 
 # The products that we will ensure are always built
 products(prefix) = [

--- a/build_tarballs.jl
+++ b/build_tarballs.jl
@@ -23,6 +23,8 @@ echo installation complete
 
 if [[ ${target} == *-w64-mingw* ]]; then
     echo $prefix
+    echo __sep__
+    pwd
     mkdir ${WORKSPACE}/destdir/tmp
     ls -R
     cp -r -L ${WORKSPACE}/destdir/lib/* ${WORKSPACE}/destdir/tmp

--- a/build_tarballs.jl
+++ b/build_tarballs.jl
@@ -19,6 +19,15 @@ cd build/
 cmake -DCMAKE_INSTALL_PREFIX=$prefix -DCMAKE_TOOLCHAIN_FILE=/opt/$target/$target.toolchain ..
 make -j${ncore}
 make install
+
+if [[ ${target} == *-w64-mingw* ]]; then
+    mkdir ${WORKSPACE}/destdir/tmp
+    cp -L ${WORKSPACE}/destdir/lib/* ${WORKSPACE}/destdir/tmp
+    rm -r ${WORKSPACE}/destdir/lib
+    mv ${WORKSPACE}/destdir/tmp ${WORKSPACE}/destdir/lib
+    ls ${WORKSPACE}/destdir/lib
+fi
+
 exit
 
 """

--- a/build_tarballs.jl
+++ b/build_tarballs.jl
@@ -18,17 +18,13 @@ cd build/
 cmake -DCMAKE_INSTALL_PREFIX=$prefix -DCMAKE_TOOLCHAIN_FILE=/opt/$target/$target.toolchain ..
 make -j${ncore}
 make install
-echo installation complete
 
 if [[ ${target} == *-w64-mingw* ]]; then
     mkdir ${WORKSPACE}/tmp
-    ls $prefix -Rl
     mv $prefix/lib/libpng.dll.a $prefix/bin # fix broken symlink
     cp -r -L $prefix/* ${WORKSPACE}/tmp
-    echo collapsed symbolic links
     rm -r $prefix
     mv ${WORKSPACE}/tmp $prefix
-    ls $prefix -Rl
 fi
 
 exit
@@ -38,8 +34,6 @@ exit
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
 platforms = supported_platforms()
-platforms = [Windows(:x86_64)]
-@show platforms
 
 # The products that we will ensure are always built
 products(prefix) = [

--- a/build_tarballs.jl
+++ b/build_tarballs.jl
@@ -22,7 +22,7 @@ make install
 
 if [[ ${target} == *-w64-mingw* ]]; then
     mkdir ${WORKSPACE}/destdir/tmp
-    cp -r -L ${WORKSPACE}/destdir/lib ${WORKSPACE}/destdir/tmp
+    cp -r -L ${WORKSPACE}/destdir/lib/* ${WORKSPACE}/destdir/tmp
     rm -r ${WORKSPACE}/destdir/lib
     mv ${WORKSPACE}/destdir/tmp ${WORKSPACE}/destdir/lib
     ls ${WORKSPACE}/destdir/lib

--- a/build_tarballs.jl
+++ b/build_tarballs.jl
@@ -23,6 +23,7 @@ echo installation complete
 
 if [[ ${target} == *-w64-mingw* ]]; then
     mkdir ${WORKSPACE}/destdir/tmp
+    ls -R
     cp -r -L ${WORKSPACE}/destdir/lib/* ${WORKSPACE}/destdir/tmp
     echo reolved symbolic links
     rm -r ${WORKSPACE}/destdir/lib

--- a/build_tarballs.jl
+++ b/build_tarballs.jl
@@ -22,6 +22,7 @@ make install
 echo installation complete
 
 if [[ ${target} == *-w64-mingw* ]]; then
+    echo $prefix
     mkdir ${WORKSPACE}/destdir/tmp
     ls -R
     cp -r -L ${WORKSPACE}/destdir/lib/* ${WORKSPACE}/destdir/tmp
@@ -38,6 +39,7 @@ exit
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
 platforms = supported_platforms()
+@show platforms
 
 # The products that we will ensure are always built
 products(prefix) = [

--- a/build_tarballs.jl
+++ b/build_tarballs.jl
@@ -11,8 +11,6 @@ sources = [
 
 # Bash recipe for building across all platforms
 script = raw"""
-echo [ ***** Start Build! *****]
-cd $WORKSPACE/srcdir
 cd $WORKSPACE/srcdir
 cd libpng-1.6.31/
 mkdir build
@@ -23,16 +21,13 @@ make install
 echo installation complete
 
 if [[ ${target} == *-w64-mingw* ]]; then
-    echo $prefix
-    echo __sep__
-    pwd
-    mkdir ${WORKSPACE}/destdir/tmp
-    ls -R
-    cp -r -L ${WORKSPACE}/destdir/lib/* ${WORKSPACE}/destdir/tmp
-    echo reolved symbolic links
-    rm -r ${WORKSPACE}/destdir/lib
-    mv ${WORKSPACE}/destdir/tmp ${WORKSPACE}/destdir/lib
-    ls ${WORKSPACE}/destdir/lib
+    mkdir ${WORKSPACE}/tmp
+    ls -Rl
+    cp -r -L $prefix/* ${WORKSPACE}/tmp
+    echo collapsed symbolic links
+    rm -r $prefix
+    mv ${WORKSPACE}/tmp $prefix
+    ls $prefix -Rl
 fi
 
 exit
@@ -42,8 +37,8 @@ exit
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
 platforms = supported_platforms()
-@show platforms
 platforms = [Windows(:x86_64)]
+@show platforms
 
 # The products that we will ensure are always built
 products(prefix) = [

--- a/build_tarballs.jl
+++ b/build_tarballs.jl
@@ -23,7 +23,7 @@ echo installation complete
 if [[ ${target} == *-w64-mingw* ]]; then
     mkdir ${WORKSPACE}/tmp
     ls $prefix -Rl
-    cp -d $prefix/lib/libpng.dll.a $prefix/bin # fix broken symlink
+    mv $prefix/lib/libpng.dll.a $prefix/bin # fix broken symlink
     cp -r -L $prefix/* ${WORKSPACE}/tmp
     echo collapsed symbolic links
     rm -r $prefix


### PR DESCRIPTION
Even though the build finished without errors, the resulting package still contained symlinks, causing errors when trying to build ImageMagick. The Windows only snippet here should fix that. There is some weird stuff going on (the `mv` command) to compensate for some of the unexpected effects of BinaryBuilder auditing.

Could you take a look and create a release if you are happy, please?